### PR TITLE
struct-id: add own-fields attribute for struct-field-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
+# Racket-generated files
 compiled/
+doc/
+
+# Editor-generated files
+*~
+\#*
+.\#*
+
+# OS-generated files
+.DS_Store

--- a/syntax-classes-doc/scribblings/syntax-classes.scrbl
+++ b/syntax-classes-doc/scribblings/syntax-classes.scrbl
@@ -238,6 +238,10 @@ value satisfies @racket[struct-info?], and it will then bind a set of attributes
   @item{The @tt{num-own-fields} attribute is like @tt{num-fields}, except that it does not count
         supertype fields, only fields that belong to the structure type itself.}
 
+  @item{The @tt{own-fields} attribute is bound to either a list of symbols containing every immediate
+        field name (not including supertype fields), or @racket[#f] if the transformer value does not
+        implement @racket[prop:struct-field-info].}
+
   @item{The @tt{own-accessor-id} attribute is like @tt{accessor-id}, except that it does not include
         supertype fields, only fields that belong to the structure type itself.}
 

--- a/syntax-classes-doc/scribblings/syntax-classes.scrbl
+++ b/syntax-classes-doc/scribblings/syntax-classes.scrbl
@@ -242,6 +242,10 @@ value satisfies @racket[struct-info?], and it will then bind a set of attributes
         field name (not including supertype fields), or @racket[#f] if the transformer value does not
         implement @racket[prop:struct-field-info].}
 
+  @item{The @tt{all-fields} attribute is bound to either a list of symbols containing every
+        field name including supertype fields which can re-use field names, or @racket[#f] if it
+        or any of its supertypes does not implement @racket[prop:struct-field-info].}
+
   @item{The @tt{own-accessor-id} attribute is like @tt{accessor-id}, except that it does not include
         supertype fields, only fields that belong to the structure type itself.}
 

--- a/syntax-classes-lib/syntax/parse/class/struct-id.rkt
+++ b/syntax-classes-lib/syntax/parse/class/struct-id.rkt
@@ -16,7 +16,7 @@
   #:description #f
   #:commit
   #:attributes [info descriptor-id constructor-id predicate-id all-fields-visible? supertype-id
-                     num-fields num-supertype-fields num-own-fields
+                     num-fields num-supertype-fields num-own-fields own-fields
                      [accessor-id 1] [mutator-id 1] [own-accessor-id 1] [own-mutator-id 1]]
   [pattern id:local-value/struct-info
     #:attr info (extract-struct-info (@ id.local-value))
@@ -41,5 +41,7 @@
                  (count identifier? (fourth supertype-info)))
                0)
     #:attr num-own-fields (- (@ num-fields) (@ num-supertype-fields))
+    #:attr own-fields (and (struct-field-info? (@ id.local-value))
+                           (reverse (struct-field-info-list (@ id.local-value))))
     #:attr [own-accessor-id 1] (take-right (@ accessor-id) (@ num-own-fields))
     #:attr [own-mutator-id 1] (take-right (@ mutator-id) (@ num-own-fields))])

--- a/syntax-classes-test/tests/syntax/parse/class/struct-id.rkt
+++ b/syntax-classes-test/tests/syntax/parse/class/struct-id.rkt
@@ -35,4 +35,16 @@
       (check-equal? (struct-own-accessors parent)
                     (list parent-a parent-b))
       (check-equal? (struct-own-accessors child)
-                    (list child-a child-b)))))
+                    (list child-a child-b))))
+
+  (describe "attribute own-fields"
+    (it "includes field symbols, but not parent fields"
+      (define-syntax struct-own-fields
+        (syntax-parser [(_ id:struct-id)
+                        #`'#,(attribute id.own-fields)]))
+      (check-equal? (struct-own-fields boring)
+                    (list))
+      (check-equal? (struct-own-fields parent)
+                    (list 'a 'b))
+      (check-equal? (struct-own-fields child)
+                    (list 'a 'b)))))

--- a/syntax-classes-test/tests/syntax/parse/class/struct-id.rkt
+++ b/syntax-classes-test/tests/syntax/parse/class/struct-id.rkt
@@ -8,8 +8,8 @@
 
 (describe "class struct-id"
   (struct boring ())
-  (struct parent (a b))
-  (struct child parent (a b))
+  (struct parent (a b p))
+  (struct child parent (a b c))
 
   (it "handles structs with no fields"
     (define-syntax get-struct-info
@@ -23,9 +23,9 @@
         (syntax-parser [(_ id:struct-id)
                         #'(list id.accessor-id ...)]))
       (check-equal? (struct-accessors parent)
-                    (list parent-a parent-b))
+                    (list parent-a parent-b parent-p))
       (check-equal? (struct-accessors child)
-                    (list parent-a parent-b child-a child-b))))
+                    (list parent-a parent-b parent-p child-a child-b child-c))))
 
   (describe "attribute own-accessor-id"
     (it "includes accessors, but not parent accessors"
@@ -33,9 +33,9 @@
         (syntax-parser [(_ id:struct-id)
                         #'(list id.own-accessor-id ...)]))
       (check-equal? (struct-own-accessors parent)
-                    (list parent-a parent-b))
+                    (list parent-a parent-b parent-p))
       (check-equal? (struct-own-accessors child)
-                    (list child-a child-b))))
+                    (list child-a child-b child-c))))
 
   (describe "attribute own-fields"
     (it "includes field symbols, but not parent fields"
@@ -45,6 +45,18 @@
       (check-equal? (struct-own-fields boring)
                     (list))
       (check-equal? (struct-own-fields parent)
-                    (list 'a 'b))
+                    (list 'a 'b 'p))
       (check-equal? (struct-own-fields child)
-                    (list 'a 'b)))))
+                    (list 'a 'b 'c))))
+
+  (describe "attribute all-fields"
+    (it "includes field symbols, but not parent fields"
+      (define-syntax struct-all-fields
+        (syntax-parser [(_ id:struct-id)
+                        #`'#,(attribute id.all-fields)]))
+      (check-equal? (struct-all-fields boring)
+                    (list))
+      (check-equal? (struct-all-fields parent)
+                    (list 'a 'b 'p))
+      (check-equal? (struct-all-fields child)
+                    (list 'a 'b 'p 'a 'b 'c)))))


### PR DESCRIPTION
Implementation to resolve #5.

This PR adds an attribute to `struct-id` called `own-fields`, containing either a list of symbols from `struct-field-info`, or `#f` if the struct-transformer-value doesn't implement that.

The `all-fields` attribute includes the parent fields, even though those names can overlap.